### PR TITLE
Add API description

### DIFF
--- a/index.nunjucks
+++ b/index.nunjucks
@@ -193,6 +193,10 @@
             <h1>{{ title }} API documentation{% if version %} <small>version {{ version }}</small>{% endif %}</h1>
             <p>{{ baseUri }}</p>
 
+            {% if description %}
+              <p>{{ description }}</p>
+            {% endif %}
+
             {% if baseUriParameters %}
               <ul>
                 {% for item in baseUriParameters %}

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "raml2html-default-theme",
   "description": "The default theme for raml2html",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "author": {
     "name": "Kevin Renskers",
     "email": "kevin@mixedcase.nl"


### PR DESCRIPTION
Render the `description` node at the root of the document.