### PR TITLE
WIP: Initial attempt at rendering annotations on types

### DIFF
--- a/item.nunjucks
+++ b/item.nunjucks
@@ -1,41 +1,51 @@
 <li>
-  <strong>{{ item.key }}</strong>:
+  <strong>{{ item.key }}</strong>{% if item.type !== nil %}:
 
-  {% if not item.structuredValue %}
-    <em>
-      {%- if item.required -%}required {% endif -%}
-      (
-      {%- if item.enum -%}
-        {%- if item.enum.length === 1 -%}
-          {{ item.enum.join(', ') }}
+    {% if not item.structuredValue %}
+      <em>
+        {%- if item.required -%}required {% endif -%}
+        (
+        {%- if item.enum -%}
+          {%- if item.enum.length === 1 -%}
+            {{ item.enum.join(', ') }}
+          {%- else -%}
+            one of {{ item.enum.join(', ') }}
+          {%- endif -%}
         {%- else -%}
-          one of {{ item.enum.join(', ') }}
+          {%- if item.type === 'array' -%}
+            array of {% if isStandardType(item.items) %}{{ item.items }}{% else %}{{ item.items.displayName }}{% endif %}
+          {%- else -%}
+            {{ item.type }}
+          {%- endif -%}
         {%- endif -%}
-      {%- else -%}
-        {%- if item.type === 'array' -%}
-          array of {% if isStandardType(item.items) %}{{ item.items }}{% else %}{{ item.items.displayName }}{% endif %}
-        {%- else -%}
-          {{ item.type }}
-        {%- endif -%}
-      {%- endif -%}
 
-      {%- if item.default or item.default == 0 or item.default == false %} - default: {{ item.default }}{%- endif -%}
-      {%- if item.repeat %} - repeat: {{ item.repeat }}{%- endif -%}
-      {%- if item.type == 'string' -%}
-        {%- if item.minLength or item.minLength == 0 %} - minLength: {{ item.minLength }}{%- endif -%}
-        {%- if item.maxLength or item.maxLength == 0 %} - maxLength: {{ item.maxLength }}{%- endif -%}
-      {%- else -%}
-        {%- if item.minimum or item.minimum == 0 %} - minimum: {{ item.minimum }}{%- endif -%}
-        {%- if item.maximum or item.maximum == 0 %} - maximum: {{ item.maximum }}{%- endif -%}
-      {%- endif -%}
-      {%- if item.pattern %} - pattern: {{ item.pattern }}{%- endif -%}
-      )
-    </em>
+        {%- if item.default or item.default == 0 or item.default == false %} - default: {{ item.default }}{%- endif -%}
+        {%- if item.repeat %} - repeat: {{ item.repeat }}{%- endif -%}
+        {%- if item.type == 'string' -%}
+          {%- if item.minLength or item.minLength == 0 %} - minLength: {{ item.minLength }}{%- endif -%}
+          {%- if item.maxLength or item.maxLength == 0 %} - maxLength: {{ item.maxLength }}{%- endif -%}
+        {%- else -%}
+          {%- if item.minimum or item.minimum == 0 %} - minimum: {{ item.minimum }}{%- endif -%}
+          {%- if item.maximum or item.maximum == 0 %} - maximum: {{ item.maximum }}{%- endif -%}
+        {%- endif -%}
+        {%- if item.pattern %} - pattern: {{ item.pattern }}{%- endif -%}
+        )
+      </em>
+    {% endif %}
   {% endif %}
 
 {% markdown %}
 {{ item.description }}
 {% endmarkdown %}
+
+  {% if item.annotations.length %}
+  <h3>Annotations</h3>
+  <ul>
+    {% for item in item.annotations %}
+    {% include "./item.nunjucks" %}
+    {% endfor %}
+  </ul>
+  {% endif %}
 
   {% if item.items and item.items.properties %}
     {% if isStandardType(item.items) %}
@@ -70,7 +80,7 @@
       {% endfor %}
     </ul>
   {% endif %}
-  
+
   {# Item Examples #}
   {% set parent = item %}
   {% include "./examples.nunjucks" %}


### PR DESCRIPTION
I’m submitting this, as @sichvoge may be interested in it. It’s not finished yet, but I wanted to see if this was starting on the right lines…

Concentrating on the semantics first, before any styling. This implements the “simple” method from [our previous discussion](https://github.com/raml2html/raml2html/issues/204#issuecomment-311037262).

Currently it will pick up on type annotations and render them next to the type.  For type annotations that are just flags (i.e. have a `nil` type) it will display only the annotation name.

Limitation: when an annotation *does* have properties, they are shown as JSON, not in a structured way. It looks like I may need to modify raml2html’s source to add a property to the `item` to say that it is an annotation.  Then I can query this in `item.nunjucks` and render it more appropriately.  Please me know if you think this is the right way to go. (An alternative would be to create another nunjucks template for annotations on types, but that seems to break DRY.)

**Test data:** I created [a very simple API](https://github.com/matatk/raml2html-test-spec) for testing.

**Update:** as suggested, here are some screen grabs :-). As I mentioned, this has only just started—it will need a lot more work before merging, but I wanted to get your input on the issue above regarding the best way to work out when an item is an annotation.

Original:
![original](https://user-images.githubusercontent.com/1125522/28912732-6258fed0-782d-11e7-9176-2a5934847602.png)

New:
![revised](https://user-images.githubusercontent.com/1125522/28912730-617926b6-782d-11e7-9ba2-af3524f7ffc8.png)