### PR TITLE
Render description as markdown

### DIFF
--- a/index.nunjucks
+++ b/index.nunjucks
@@ -194,7 +194,9 @@
             <p>{{ baseUri }}</p>
 
             {% if description %}
-              <p>{{ description }}</p>
+              {% markdown %}
+              {{ description }}
+              {% endmarkdown %}
             {% endif %}
 
             {% if baseUriParameters %}


### PR DESCRIPTION
According to [raml 1.0 spec](https://github.com/raml-org/raml-spec/blob/master/versions/raml-10/raml-10.md#the-root-of-the-document) description could be formatted using markdown, so it should be rendered as markdown =)