### PR TITLE
use provided title only or default generic title

### DIFF
--- a/index.nunjucks
+++ b/index.nunjucks
@@ -1,7 +1,7 @@
 <!DOCTYPE HTML>
 <html>
   <head>
-    <title>{{ title }} API documentation</title>
+    <title>{% if title %}{{ title }}{% else %}API Documentation{% endif %}</title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <meta name="generator" content="https://github.com/raml2html/raml2html {{ config.raml2HtmlVersion }}">
@@ -25,7 +25,7 @@
       <div class="row">
         <div class="col-md-9" role="main">
           <div class="page-header">
-            <h1>{{ title }} API documentation{% if version %} <small>version {{ version }}</small>{% endif %}</h1>
+            <h1>{% if title %}{{ title }}{% else %}API Documentation{% endif %}{% if version %} <small>version {{ version }}</small>{% endif %}</h1>
             <p>{{ baseUri }}</p>
 
             {% if description %}


### PR DESCRIPTION
The purpose of this proposed change is accomplish two things.

* Give users complete control over the _title_ content.
* Provide a default _title_ with proper capitalization.

Appending _API documentation_ to the end of a user-defined title, which may already include those words, is an unexpected side effect. I understand that users of this theme have learned that this is how this theme renders their RAML docs, and changing it could cause some confusion, but giving them complete control over the title is better in my opinion.

If this change cannot be merged, please consider changing the appended _API documentation_ text to _API Documentation_ since it is a title.