### PR TITLE
Display body schema

### DIFF
--- a/resource.nunjucks
+++ b/resource.nunjucks
@@ -439,6 +439,11 @@
                               {% endif %}
                             {% endif %}
 
+                            {% if b.schema %}
+                                <p><strong>Schema</strong>:</p>
+                                <pre><code>{{ b.schema | escape }}</code></pre>
+                            {% endif %}
+
                             {% if b.content %}
                               <p><strong>Content</strong>:</p>
                               <pre><code>{{ b.content | escape }}</code></pre>

--- a/resource.nunjucks
+++ b/resource.nunjucks
@@ -201,6 +201,11 @@
                           {% endif %}
                         {% endif %}
 
+                        {% if b.schema %}
+                            <p><strong>Schema</strong>:</p>
+                            <pre><code>{{ b.schema | escape }}</code></pre>
+                        {% endif %}
+
                         {% if b.content %}
                           <p><strong>Content</strong>:</p>
                           <pre><code>{{ b.content | escape }}</code></pre>
@@ -305,6 +310,11 @@
                               <p><strong>Type</strong>:</p>
                               <pre><code>{{ b.type | escape }}</code></pre>
                             {% endif %}
+                          {% endif %}
+
+                          {% if b.schema %}
+                              <p><strong>Schema</strong>:</p>
+                              <pre><code>{{ b.schema | escape }}</code></pre>
                           {% endif %}
 
                           {% if b.content %}


### PR DESCRIPTION
In this PR `body.schema` is displayed (when presented).
`body.schema` still (using raml 1.0) can be used and even may be useful e.g. when using inline json schema:

```yaml
      responses:
        '200':
          body:
            application/json:
              schema: |
                {
                  "$schema": "http://json-schema.org/draft-04/schema#",
                  "type": "object",
                  "properties": {
                    "_id": {
                      "type": "integer",
                      "minimum": 1
                    }
                  }
                }
              example:
                _id: 1
```
